### PR TITLE
feat: Add unrar to dnf packages

### DIFF
--- a/dnf-packages.txt
+++ b/dnf-packages.txt
@@ -13,6 +13,7 @@ neofetch
 cmatrix
 p7zip
 unzip
+unrar
 gparted
 nikto
 nmap


### PR DESCRIPTION
Simple PR that adds unrar to the list of DNF packages to install on the system. This will let the user handle any .rar file in the future. 