### PR TITLE
ignore

### DIFF
--- a/dnf-packages.txt
+++ b/dnf-packages.txt
@@ -13,6 +13,7 @@ neofetch
 cmatrix
 p7zip
 unzip
+unrar
 gparted
 nikto
 nmap

--- a/fedora-setup.sh
+++ b/fedora-setup.sh
@@ -96,7 +96,8 @@ while [ "$CHOICE -ne 4" ]; do
             notify-send "All done" --expire-time=10
            ;;
         9)  echo "Installing Nvidia Driver Akmod-Nvidia"
-            sudo dnf install -y akmod-nvidia
+            sudo dnf install -y akmod-nvidia 
+            sudo dnf install -y xorg-x11-drv-nvidia-cuda # Used for cuda/nvdec/nvenc support.
             notify-send "All done" --expire-time=10
 	       ;;
         10)


### PR DESCRIPTION
Another simple PR that installs xorg-x11-drv-nvidia-cuda, its optional but should be installed by default. 

Sidenote: Should we maybe send the user a notification after drivers are installed to let them know that a reboot is required to finalize the driver install? Something like: 
`notify-send "NVIDIA drivers installed" "Please reboot to finalize driver installation." --expire-time=5000`