### PR TITLE
 Add missing nvidia dependencies 

### DIFF
--- a/fedora-setup.sh
+++ b/fedora-setup.sh
@@ -97,6 +97,7 @@ while [ "$CHOICE -ne 4" ]; do
            ;;
         9)  echo "Installing Nvidia Driver Akmod-Nvidia"
             sudo dnf install -y akmod-nvidia
+            sudo dnf install -y xorg-x11-drv-nvidia-cuda #optional for cuda/nvdec/nvenc support
             notify-send "All done" --expire-time=10
 	       ;;
         10)


### PR DESCRIPTION
Installs xorg-x11-drv-nvidia-cuda, its optional but should be installed by default.

Side note: Should we maybe send the user a notification after drivers are installed to let them know that a reboot is required to finalize the driver install? Something like: 
`notify-send "NVIDIA drivers installed" "Please reboot to finalize driver installation." --expire-time=5000`